### PR TITLE
Tone block disappears in Microbit [sc-29312]

### DIFF
--- a/libs/core/music.ts
+++ b/libs/core/music.ts
@@ -199,7 +199,6 @@ namespace music {
     //% parts="headphone"
     //% useEnumVal=1
     //% group="Tone"
-    //% deprecated=1
     export function playTone(frequency: number, ms: number): void {
         if (isNaN(frequency) || isNaN(ms)) return;
         if (_playTone) _playTone(frequency, ms);


### PR DESCRIPTION
- Repopulate hidden play tone block 

Created from this [Shortcut Story](https://app.shortcut.com/skillstruck/story/29312/tone-block-disappears-in-microbit)