### PR TITLE
Keep Extensions accessible inside tutorials/lessons [sc-33226]

### DIFF
--- a/editor/extension.tsx
+++ b/editor/extension.tsx
@@ -57,7 +57,8 @@ pxt.editor.initExtensionsAsync = function (opts: pxt.editor.ExtensionOptions): P
 function setupTutorialFullToolbox(projectView: pxt.editor.IProjectView) {
     if (!projectView) return;
     const pv = projectView as any;
-    setInterval(() => {
+    if (pv._ssTutorialFullToolboxInterval) return;
+    pv._ssTutorialFullToolboxInterval = setInterval(() => {
         try {
             if (typeof pv.isTutorial !== "function" || !pv.isTutorial()) return;
             const editorState = pv.state && pv.state.editorState;

--- a/editor/extension.tsx
+++ b/editor/extension.tsx
@@ -61,13 +61,20 @@ function setupTutorialFullToolbox(projectView: pxt.editor.IProjectView) {
     pv._ssTutorialFullToolboxInterval = setInterval(() => {
         try {
             if (typeof pv.isTutorial !== "function" || !pv.isTutorial()) return;
-            const editorState = pv.state && pv.state.editorState;
-            if (!editorState) return;
-            const filters = editorState.filters;
-            if (!filters || (!filters.blocks && !filters.namespaces)) return;
-            const next = Object.assign({}, editorState);
-            delete next.filters;
-            pv.setState({ editorState: next }, () => {
+            // Cheap stale-state check so we don't fire setState every tick when
+            // there's nothing to clear; the actual update uses the functional
+            // form below so it applies against the latest committed state.
+            const staleEditorState = pv.state && pv.state.editorState;
+            if (!staleEditorState) return;
+            const staleFilters = staleEditorState.filters;
+            if (!staleFilters || (!staleFilters.blocks && !staleFilters.namespaces)) return;
+            pv.setState((prev: any) => {
+                const editorState = prev && prev.editorState;
+                if (!editorState || !editorState.filters) return null;
+                const next = Object.assign({}, editorState);
+                delete next.filters;
+                return { editorState: next };
+            }, () => {
                 try {
                     const ed = pv.editor;
                     if (ed && typeof ed.refreshToolbox === "function") {

--- a/editor/extension.tsx
+++ b/editor/extension.tsx
@@ -41,5 +41,45 @@ pxt.editor.initExtensionsAsync = function (opts: pxt.editor.ExtensionOptions): P
     res.mkPacketIOWrapper = flash.mkDAPLinkPacketIOWrapper;
     res.blocklyPatch = patch.patchBlocks;
     res.showProgramTooLargeErrorAsync = dialogs.showProgramTooLargeErrorAsync;
+
+    setupTutorialFullToolbox(opts.projectView);
+
     return Promise.resolve<pxt.editor.ExtensionResult>(res);
+}
+
+// Skill Struck: tutorial mode normally sets editorState.filters.blocks from
+// the tutorial's usedBlocks set, hiding any toolbox category whose blocks
+// aren't referenced in the tutorial markdown — including extensions a student
+// just installed. We poll for that filter while a tutorial is active and clear
+// it, then force the blocks editor to refresh its toolbox so the new deps
+// (e.g. NeoPixel + Sonar) all appear. Step progression and the rest of the
+// tutorial UI are unaffected.
+function setupTutorialFullToolbox(projectView: pxt.editor.IProjectView) {
+    if (!projectView) return;
+    const pv = projectView as any;
+    setInterval(() => {
+        try {
+            if (typeof pv.isTutorial !== "function" || !pv.isTutorial()) return;
+            const editorState = pv.state && pv.state.editorState;
+            if (!editorState) return;
+            const filters = editorState.filters;
+            if (!filters || (!filters.blocks && !filters.namespaces)) return;
+            const next = Object.assign({}, editorState);
+            delete next.filters;
+            pv.setState({ editorState: next }, () => {
+                try {
+                    const ed = pv.editor;
+                    if (ed && typeof ed.refreshToolbox === "function") {
+                        ed.refreshToolbox();
+                    } else if (typeof pv.forceUpdate === "function") {
+                        pv.forceUpdate();
+                    }
+                } catch (e) {
+                    pxt.debug("refreshToolbox after clear failed: " + e);
+                }
+            });
+        } catch (e) {
+            pxt.debug("clearTutorialFilters failed: " + e);
+        }
+    }, 250);
 }


### PR DESCRIPTION
## Summary

Lets students self-add MakeCode extensions (NeoPixel, Sonar, Maqueen, Cutebot, OLED, etc.) from inside a Skill Struck lesson — previously the Extensions button and any newly-installed extension's blocks were hidden by MakeCode's tutorial-mode toolbox filter.

## Why

MakeCode tutorial mode populates `editorState.filters.blocks` from the tutorial markdown's `usedBlocks` set, which hides any toolbox category whose blocks aren't referenced in the tutorial. That filter also hides:

- The Extensions ("Add Package") button — it's a custom category with no blocks, so it never matches the filter.
- Any extension a student installs mid-lesson — its blocks aren't in the original `usedBlocks` set.

This made it impossible for the wrapper at https://github.com/skillstruck/microbit to let students add kit-specific extensions during challenges.

## What changed

`editor/extension.tsx` — adds a `setupTutorialFullToolbox` hook that runs during editor init. While `projectView.isTutorial()` is true, it polls (250ms) for `editorState.filters` and clears it via `setState`, then calls the blocks editor's `refreshToolbox()` so newly-loaded extension categories actually show up. When no tutorial is active it's a no-op.

Tutorial step progression, hints, and completion events are unaffected — they're driven by `tutorialOptions`, not `editorState.filters`.

## Reviewer notes

- The 250ms interval is intentional: package install can re-apply the tutorial filter mid-flow, so we need to undo it quickly enough that students don't see categories disappear after adding an extension. The setState is a no-op when filters are already clear.
- Tested with: install NeoPixel, then install Sonar — both categories remain visible. Existing built-ins (Radio, OLED) and the native MakeCode Extensions entry continue to render in their normal toolbox positions; this PR removes the need for a custom-injected Extensions row I had in an earlier draft.
- If lessons depend on MakeCode's built-in tutorial validation (e.g. "did the student place block X?"), please sanity-check one such lesson — validation shouldn't depend on `filters`, but worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)