### PR TITLE
Fall back to approvedRepoLib when /api/ghsearch missing [sc-33610]

### DIFF
--- a/editor/extension.tsx
+++ b/editor/extension.tsx
@@ -43,6 +43,7 @@ pxt.editor.initExtensionsAsync = function (opts: pxt.editor.ExtensionOptions): P
     res.showProgramTooLargeErrorAsync = dialogs.showProgramTooLargeErrorAsync;
 
     setupTutorialFullToolbox(opts.projectView);
+    setupGhSearchFallback();
 
     return Promise.resolve<pxt.editor.ExtensionResult>(res);
 }
@@ -90,4 +91,82 @@ function setupTutorialFullToolbox(projectView: pxt.editor.IProjectView) {
             pxt.debug("clearTutorialFilters failed: " + e);
         }
     }, 250);
+}
+
+// Skill Struck: the static-pack editor calls `${apiRoot}ghsearch/<target>/<platform>?q=<query>`
+// to populate the Extensions panel home view (preferred slugs joined by `|`) and the user-typed
+// search results. In production `apiRoot` resolves to `/api/` (pxt.Cloud.apiRoot falls back to
+// `/api/` when not on localhost), so the request hits the hosted edge router. That router
+// implements `/api/gh/<owner>/<repo>/...` for individual package metadata but NOT
+// `/api/ghsearch/`, so the SPA catch-all returns the editor's index.html with HTTP 200. The
+// JSON parse fails, the extensions code treats it as empty, and every external approvedRepoLib
+// repo (neopixel, sonar, oled, maqueen, cutebot, microturtle, ...) silently vanishes from the
+// panel while bundled libs still render.
+//
+// Patch httpGetJsonAsync to intercept ghsearch URLs: if the real response doesn't come back as
+// a usable items array, synthesize one from the already-loaded approvedRepoLib so the panel
+// can render tiles. Individual repo metadata still comes through the real /api/gh/ proxy.
+function setupGhSearchFallback() {
+    const U: any = (pxt as any).U || (pxt as any).Util;
+    if (!U || typeof U.httpGetJsonAsync !== "function") return;
+    if (U._ssGhSearchPatched) return;
+    U._ssGhSearchPatched = true;
+    const orig = U.httpGetJsonAsync;
+    U.httpGetJsonAsync = function (url: string): Promise<any> {
+        if (typeof url !== "string" || !/\/api\/ghsearch\//.test(url)) {
+            return orig.call(U, url);
+        }
+        return orig.call(U, url).then(
+            (resp: any) => {
+                if (resp && Array.isArray(resp.items)) return resp;
+                return synthesizeGhSearchResponse(url);
+            },
+            () => synthesizeGhSearchResponse(url)
+        );
+    };
+}
+
+function synthesizeGhSearchResponse(url: string): Promise<{ items: any[] }> {
+    const m = url.match(/[?&]q=([^&]+)/);
+    if (!m) return Promise.resolve({ items: [] });
+    let query = "";
+    try {
+        query = decodeURIComponent(m[1]);
+    } catch (e) {
+        query = m[1];
+    }
+    const terms = query.split("|").map(s => s.trim()).filter(Boolean);
+    if (!terms.length) return Promise.resolve({ items: [] });
+    return (pxt as any).targetConfigAsync().then(
+        (cfg: any) => {
+            const lib = cfg && cfg.packages && cfg.packages.approvedRepoLib;
+            if (!lib) return { items: [] };
+            const entries = Object.keys(lib).map(k => ({ slug: k, meta: lib[k] || {} }));
+            const matched: { [slug: string]: { slug: string; meta: any } } = {};
+            for (const term of terms) {
+                const needle = term.toLowerCase();
+                const exact = entries.filter(e => e.slug.toLowerCase() === needle)[0];
+                if (exact) {
+                    matched[exact.slug] = exact;
+                    continue;
+                }
+                for (const e of entries) {
+                    const repoPart = (e.slug.split("/")[1] || e.slug).toLowerCase();
+                    if (repoPart.indexOf(needle) >= 0) matched[e.slug] = e;
+                }
+            }
+            const items = Object.keys(matched).map(slug => ({
+                full_name: slug,
+                name: slug.split("/")[1] || slug,
+                description: "",
+                default_branch: "master",
+                private: false,
+                fork: false,
+                updated_at: new Date(0).toISOString(),
+                stargazers_count: 0
+            }));
+            return { items };
+        },
+        () => ({ items: [] as any[] })
+    );
 }


### PR DESCRIPTION
## Summary
- Extensions panel on hosted (`roboticseditor.test.skillstruck.com`) showed only bundled libs — every external `approvedRepoLib` repo (neopixel, sonar, oled, maqueen, cutebot, microturtle, …) was missing from both the home view and search.
- Root cause: the editor calls `${pxt.Cloud.apiRoot}ghsearch/<target>/<platform>?q=…` to populate external repo tiles. In production `apiRoot` is `/api/`, and the hosted edge router has no handler for `/api/ghsearch/` — the SPA catch-all returns `index.html` with HTTP 200. The JSON parse fails, the Extensions code treats it as empty, no external tiles render. (Individual `/api/gh/<owner>/<repo>/…` calls work fine — that's why bundled and tag-chip flows partly worked.)
- Fix: patch `pxt.U.httpGetJsonAsync` in `editor/extension.tsx` to intercept `/api/ghsearch/` URLs. If the real response is a valid `{ items: [...] }` array, use it. Otherwise (HTML fallback, network error, empty), synthesize an `items` list from the editor's already-loaded `approvedRepoLib`.

## Why this approach
- **Self-contained in `pxt-microbit`** — no Cloudflare/edge proxy changes required, ships with the next `pxt staticpkg` redeploy.
- **Doesn't disable the real endpoint** — if/when the proxy team adds `/api/ghsearch/` (or proxies to `https://www.makecode.com/api/ghsearch/`), this code passes through their response unchanged. The synthesis is a *fallback*, not a replacement.
- **Local dev unaffected** — `pxt serve` sets `apiRoot` to `https://www.makecode.com/api/`, which already returns valid items; the fallback never fires.
- **Data source is canonical** — `approvedRepoLib` is the same source the panel uses to decide repo approval status, so synthesized items pass every downstream filter.

## What's not in this PR
- The hosted edge router still SPA-fallbacks unknown `/api/*` to `index.html`. That's a server-side concern (Cloudflare Worker / Pages Function / whatever fronts `roboticseditor.test.skillstruck.com`) and should be tracked separately — every future missing endpoint will silently break the same way.
- Synthesized items lack the prettier metadata Microsoft's upstream returns (description, star count). They render as plain tiles with name + tags — the install flow still works because individual repo fetches go through the working `/api/gh/<owner>/<repo>` proxy.

## Pairs with
- [microbit#193](https://github.com/skillstruck/microbit/pull/193) — wrapper-side fix that restored tutorial Step UI by removing the package-block trigger that was crashing tutorial init.

## Test plan
- [ ] `pxt staticpkg` cleanly, push `built/packaged/` to hosted.
- [ ] Open `elementary.test.skillstruck.com/lessons/5423/robotics/300`, open Extensions panel.
- [ ] Home view: neopixel, sonar, oled-ssd1306, maqueen, cutebot, microturtle tiles render.
- [ ] Click "Lights and Display" chip → neopixel + oled-ssd1306 appear.
- [ ] Click "Robotics" chip → maqueen + cutebot appear (they were partly there before; verify still present).
- [ ] Search "neo" → neopixel result appears.
- [ ] Click neopixel → confirm it installs and the NeoPixel toolbox category appears in-lesson.
- [ ] Smoke local dev with `pxt serve`: confirm Extensions panel still works exactly as before (passthrough path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)