### PR TITLE
Also patch pxt.github.repoAsync for slug-list home view path [sc-33610]

### DIFF
--- a/editor/extension.tsx
+++ b/editor/extension.tsx
@@ -44,6 +44,7 @@ pxt.editor.initExtensionsAsync = function (opts: pxt.editor.ExtensionOptions): P
 
     setupTutorialFullToolbox(opts.projectView);
     setupGhSearchFallback();
+    setupGitHubRepoFallback();
 
     return Promise.resolve<pxt.editor.ExtensionResult>(res);
 }
@@ -169,4 +170,61 @@ function synthesizeGhSearchResponse(url: string): Promise<{ items: any[] }> {
         },
         () => ({ items: [] as any[] })
     );
+}
+
+// Skill Struck: pxt.github.searchAsync fast-paths a slug-list query (which is
+// what the Extensions home view sends — every preferred slug joined by `|`)
+// through pxt.github.repoAsync per slug, NEVER hitting the ghsearch endpoint
+// the previous setupGhSearchFallback() handles. repoAsync delegates to a proxy
+// at `${apiRoot}gh/<owner>/<repo>`; when that proxy can't answer for a slug
+// (404, SPA fallback, missing org, etc.) the helper resolves to undefined and
+// the tile silently disappears — that's the home-view symptom on the hosted
+// editor even though approvedRepoLib has every kit package.
+//
+// Patch repoAsync to keep the proxy path as the primary source (so real
+// metadata still flows through when available) and only synthesize a minimal
+// repo object from approvedRepoLib when the proxy returns nothing.
+function setupGitHubRepoFallback() {
+    const github: any = (pxt as any).github;
+    if (!github || typeof github.repoAsync !== "function") return;
+    if (github._ssRepoFallbackPatched) return;
+    github._ssRepoFallbackPatched = true;
+    const orig = github.repoAsync;
+    github.repoAsync = async function (repopath: string, config: any) {
+        let result: any;
+        try {
+            result = await orig.call(github, repopath, config);
+        } catch (e) {
+            result = undefined;
+        }
+        if (result) return result;
+        return synthesizeRepoFromApprovedLib(repopath, config);
+    };
+}
+
+function synthesizeRepoFromApprovedLib(repopath: string, config: any): any {
+    if (!repopath || !config) return undefined;
+    const lib = config.approvedRepoLib;
+    if (!lib) return undefined;
+    const cleaned = String(repopath).split("#")[0].split("?")[0];
+    const parts = cleaned.split("/").filter(Boolean);
+    if (parts.length < 2) return undefined;
+    const owner = parts[0];
+    const name = parts[1];
+    const fullName = owner + "/" + name;
+    const needle = fullName.toLowerCase();
+    const matched = Object.keys(lib).filter(k => k.toLowerCase() === needle)[0];
+    if (!matched) return undefined;
+    return {
+        github: true,
+        owner: owner.toLowerCase(),
+        fullName: matched,
+        fileName: undefined,
+        slug: matched.toLowerCase(),
+        name: name,
+        description: "",
+        defaultBranch: "master",
+        tag: undefined,
+        status: 1  // pxt.github.GitRepoStatus.Approved
+    };
 }

--- a/editor/extension.tsx
+++ b/editor/extension.tsx
@@ -195,6 +195,7 @@ function setupGitHubRepoFallback() {
         try {
             result = await orig.call(github, repopath, config);
         } catch (e) {
+            pxt.debug("repoAsync proxy failed for " + repopath + ", falling back: " + e);
             result = undefined;
         }
         if (result) return result;
@@ -225,6 +226,6 @@ function synthesizeRepoFromApprovedLib(repopath: string, config: any): any {
         description: "",
         defaultBranch: "master",
         tag: undefined,
-        status: 1  // pxt.github.GitRepoStatus.Approved
+        status: pxt.github.GitRepoStatus.Approved
     };
 }


### PR DESCRIPTION
## Summary
- Follow-up to [pxt-microbit#6](https://github.com/skillstruck/pxt-microbit/pull/6). After deploying that fix, the hosted Extensions panel home view *still* showed only bundled libs — neopixel, sonar, microturtle, oled, maqueen, cutebot were all missing.
- Tested live in the hosted iframe console: \`pxt.U._ssGhSearchPatched === true\` (patch loaded), \`pxt.U.httpGetJsonAsync('/api/ghsearch/microbit/microbit?q=microsoft%2Fpxt-neopixel%7Celecfreaks%2Fpxt-cutebot')\` returned \`{count: 2, items: [...]}\` (synthesis working). But the home view didn't fire a \`ghsearch\` request at all.
- Root cause: \`pxt.github.searchAsync\` in [pxt-core/built/pxtlib.js:494851](../node_modules/pxt-core/built/pxtlib.js) fast-paths slug-list queries:

  \`\`\`js
  function searchAsync(query, config) {
      if (!config) return Promise.resolve([]);
      let repos = query.split('|').map(parseRepoId).filter(repo => !!repo);
      if (repos.length > 0)
          return Promise.all(repos.map(id => repoAsync(id.fullName, config)))
              .then(rs => rs.filter(r => r && r.status != GitRepoStatus.Banned));
      // ...only here does it fall through to ghsearch
  }
  \`\`\`

  The home view's query is every preferred slug joined by \`|\` — \`parseRepoId\` succeeds on every one — so the code goes through \`repoAsync\` per slug and **never hits the ghsearch endpoint #6's fallback handles**. \`repoAsync\` delegates to a proxy at \`${apiRoot}gh/<owner>/<repo>\`; when that proxy returns nothing for a slug, \`proxyRepoAsync\` resolves to \`undefined\` and \`searchAsync\`'s filter drops it.

## What this PR does
- Wraps \`pxt.github.repoAsync\` with the same fallback pattern \`setupGhSearchFallback\` uses for ghsearch.
- Primary path is unchanged: the real proxy gets called first. If it returns a real repo object, we hand it back untouched — real metadata still flows.
- Only when the proxy resolves to \`undefined\` (or throws) do we synthesize a minimal repo object from \`approvedRepoLib\`: same shape as \`proxyRepoAsync\`'s success path, with \`status: Approved\` so \`searchAsync\`'s downstream filter keeps it.
- Synthesis uses the canonical slug from \`approvedRepoLib\` (case-correct), \`defaultBranch: "master"\` as a placeholder (overridden by real fetches at install time), and no description/tag/fileName.

## Why this is paired with rather than instead of #6
\`setupGhSearchFallback\` from #6 still matters for the user-typed search code path (e.g., searching "neo" in the panel). \`searchAsync\` only routes to \`repoAsync\` when every term in the query parses as a valid \`owner/repo\` slug — typed free-text searches still flow through ghsearch. Both fallbacks are needed.

## Pairs with
- [pxt-microbit#6](https://github.com/skillstruck/pxt-microbit/pull/6) (merged) — ghsearch fallback for free-text search.
- [microbit#193](https://github.com/skillstruck/microbit/pull/193) (merged) — wrapper-side fix that restored tutorial Step UI.

## Test plan
- [ ] After merging, rerun \`pxt staticpkg\` and redeploy \`built/packaged/\` to \`roboticseditor.test.skillstruck.com\`. Bust the Cloudflare cache for \`main.js\`.
- [ ] Hard-reload \`elementary.test.skillstruck.com/lessons/5423/robotics/300\`.
- [ ] Open Extensions panel — confirm \`neopixel\`, \`sonar\`, \`microturtle\`, \`oled-ssd1306\`, \`maqueen\`, \`cutebot\` tiles render on the home view alongside the bundled libs.
- [ ] Search "neo" — should return \`pxt-neopixel\` (handled by #6 fallback).
- [ ] Click \`neopixel\` → install → confirm the NeoPixel toolbox category appears in-lesson and a NeoPixel block can be dragged. (This validates that synthesis doesn't break the install flow — the install does its own real proxy fetch and uses the real defaultBranch.)
- [ ] Console check after the deploy:
  \`\`\`js
  pxt.github._ssRepoFallbackPatched  // expect true
  pxt.github.repoAsync('microsoft/pxt-neopixel', (await pxt.targetConfigAsync()).packages).then(r => r?.fullName)
  // expect "microsoft/pxt-neopixel"
  \`\`\`
- [ ] Smoke local dev with \`pxt serve\`: confirm Extensions panel still works identically (passthrough path; real GitHub data continues to load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)