### PR TITLE
Fix Extensions panel external tiles + maqueen install on target v7 [sc-33610]

### DIFF
--- a/editor/extension.tsx
+++ b/editor/extension.tsx
@@ -45,6 +45,7 @@ pxt.editor.initExtensionsAsync = function (opts: pxt.editor.ExtensionOptions): P
     setupTutorialFullToolbox(opts.projectView);
     setupGhSearchFallback();
     setupGitHubRepoFallback();
+    setupGitHubSearchFallback();
 
     return Promise.resolve<pxt.editor.ExtensionResult>(res);
 }
@@ -227,5 +228,78 @@ function synthesizeRepoFromApprovedLib(repopath: string, config: any): any {
         defaultBranch: "master",
         tag: undefined,
         status: pxt.github.GitRepoStatus.Approved
+    };
+}
+
+// Skill Struck: setupGitHubRepoFallback patches the namespace-level
+// pxt.github.repoAsync, but pxt.github.searchAsync's body references repoAsync
+// via *closure binding* to the local function declaration — not via
+// pxt.github.repoAsync. So when the data provider calls
+// pxt.github.searchAsync('slug1|slug2|...', packages) for the Extensions panel
+// home view, the per-slug repoAsync calls go through the unpatched closure
+// reference, return undefined for whatever the hosted proxy can't answer for,
+// and the final filter drops them. Result: searchAsync returns 0 items even
+// though approvedRepoLib has every preferred slug and the namespace-level
+// repoAsync patch correctly returns synthesized objects when called directly.
+//
+// Wrap pxt.github.searchAsync itself (which the data provider DOES access by
+// property lookup) and patch up missing entries from approvedRepoLib after
+// the original runs. Slug-list queries (home view) get exact-match synthesis;
+// free-text queries (search bar like "neo") get substring-match synthesis
+// against repo names. When the original returns valid items (e.g., on local
+// dev hitting makecode.com), they pass through unchanged.
+function setupGitHubSearchFallback() {
+    const github: any = (pxt as any).github;
+    if (!github || typeof github.searchAsync !== "function") return;
+    if (github._ssSearchFallbackPatched) return;
+    github._ssSearchFallbackPatched = true;
+    const orig = github.searchAsync;
+    github.searchAsync = async function (query: string, config: any) {
+        let result: any[] = [];
+        try {
+            const r = await orig.call(github, query, config);
+            if (Array.isArray(r)) result = r;
+        } catch (e) {
+            pxt.debug("searchAsync original failed, falling back: " + e);
+            result = [];
+        }
+        if (!query || !config || !config.approvedRepoLib) return result;
+
+        const got: { [k: string]: boolean } = {};
+        for (const r of result) {
+            if (r && r.fullName) got[String(r.fullName).toLowerCase()] = true;
+        }
+
+        const lib = config.approvedRepoLib;
+        const libSlugs = Object.keys(lib);
+        const terms = String(query).split("|").map(s => s.trim()).filter(Boolean);
+
+        for (const term of terms) {
+            const synth = synthesizeRepoFromApprovedLib(term, config);
+            if (synth) {
+                const key = String(synth.fullName).toLowerCase();
+                if (!got[key]) {
+                    result.push(synth);
+                    got[key] = true;
+                }
+                continue;
+            }
+            // No exact slug match — treat as free text and substring-match
+            // against the repo half of each approved slug.
+            const needle = term.toLowerCase();
+            for (const slug of libSlugs) {
+                if (got[slug.toLowerCase()]) continue;
+                const repoPart = (slug.split("/")[1] || slug).toLowerCase();
+                if (repoPart.indexOf(needle) >= 0) {
+                    const s = synthesizeRepoFromApprovedLib(slug, config);
+                    if (s) {
+                        const key = String(s.fullName).toLowerCase();
+                        result.push(s);
+                        got[key] = true;
+                    }
+                }
+            }
+        }
+        return result;
     };
 }

--- a/editor/extension.tsx
+++ b/editor/extension.tsx
@@ -256,50 +256,70 @@ function setupGitHubSearchFallback() {
     const orig = github.searchAsync;
     github.searchAsync = async function (query: string, config: any) {
         let result: any[] = [];
+        let originalError: any = null;
         try {
             const r = await orig.call(github, query, config);
             if (Array.isArray(r)) result = r;
         } catch (e) {
-            pxt.debug("searchAsync original failed, falling back: " + e);
-            result = [];
+            pxt.debug("searchAsync original failed, attempting fallback: " + e);
+            originalError = e;
         }
-        if (!query || !config || !config.approvedRepoLib) return result;
-
-        const got: { [k: string]: boolean } = {};
-        for (const r of result) {
-            if (r && r.fullName) got[String(r.fullName).toLowerCase()] = true;
+        // No fallback data available — preserve the original promise outcome
+        // so the data provider's .catch(handleNetworkError) still fires.
+        if (!query || !config || !config.approvedRepoLib) {
+            if (originalError) throw originalError;
+            return result;
         }
 
         const lib = config.approvedRepoLib;
         const libSlugs = Object.keys(lib);
         const terms = String(query).split("|").map(s => s.trim()).filter(Boolean);
 
+        // Index whatever the original returned so we can prefer its richer
+        // metadata over a synthesized stub when both are available for the
+        // same slug.
+        const bySlug: { [k: string]: any } = {};
+        for (const r of result) {
+            if (r && r.fullName) bySlug[String(r.fullName).toLowerCase()] = r;
+        }
+
+        // Build the final array in query/terms order rather than mutating the
+        // original in place — keeps curated-tile sequence intact for partial
+        // upstream hits.
+        const ordered: any[] = [];
+        const seen: { [k: string]: boolean } = {};
+        const emit = (repo: any) => {
+            if (!repo || !repo.fullName) return;
+            const key = String(repo.fullName).toLowerCase();
+            if (seen[key]) return;
+            ordered.push(repo);
+            seen[key] = true;
+        };
+
         for (const term of terms) {
             const synth = synthesizeRepoFromApprovedLib(term, config);
             if (synth) {
                 const key = String(synth.fullName).toLowerCase();
-                if (!got[key]) {
-                    result.push(synth);
-                    got[key] = true;
-                }
+                emit(bySlug[key] || synth);
                 continue;
             }
-            // No exact slug match — treat as free text and substring-match
-            // against the repo half of each approved slug.
+            // Free-text term — substring-match against the repo half of each
+            // approved slug, emitting matches for this term before moving on.
             const needle = term.toLowerCase();
             for (const slug of libSlugs) {
-                if (got[slug.toLowerCase()]) continue;
+                const key = slug.toLowerCase();
+                if (seen[key]) continue;
                 const repoPart = (slug.split("/")[1] || slug).toLowerCase();
                 if (repoPart.indexOf(needle) >= 0) {
-                    const s = synthesizeRepoFromApprovedLib(slug, config);
-                    if (s) {
-                        const key = String(s.fullName).toLowerCase();
-                        result.push(s);
-                        got[key] = true;
-                    }
+                    emit(bySlug[key] || synthesizeRepoFromApprovedLib(slug, config));
                 }
             }
         }
-        return result;
+        // Defensive: surface any original results not requested via terms so
+        // we never strictly subtract from the upstream response.
+        for (const r of result) emit(r);
+
+        if (!ordered.length && originalError) throw originalError;
+        return ordered;
     };
 }

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -1,10 +1,10 @@
 {
-    "releases": {
-        "v7": [
-            "DFRobot/pxt-maqueen#v1.7.16"
-        ]
-    },
     "packages": {
+        "releases": {
+            "v7": [
+                "DFRobot/pxt-maqueen#v1.7.16"
+            ]
+        },
         "approvedRepoLib": {
             "microsoft/pxt-neopixel": {
                 "tags": [ "Lights and Display" ],

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -1,4 +1,9 @@
 {
+    "releases": {
+        "v7": [
+            "DFRobot/pxt-maqueen#v1.7.16"
+        ]
+    },
     "packages": {
         "approvedRepoLib": {
             "microsoft/pxt-neopixel": {


### PR DESCRIPTION
## What this fixes

On hosted (`roboticseditor.test.skillstruck.com`), the Extensions panel was showing only bundled libs — every external `approvedRepoLib` repo (neopixel, sonar, oled, maqueen, cutebot, microturtle, …) was missing. After fixing the panel rendering, installing maqueen separately errored with `"maqueen requires target version 8.0.22 (you are running 7.1.24)"`.

## What this PR does

Four small editor-side changes, all in `editor/extension.tsx` + one config tweak in `targetconfig.json`:

| Commit | Patches | Why |
|---|---|---|
| 8849a88 | `pxt.U.httpGetJsonAsync` | Hosted `/api/ghsearch/` SPA-fallbacks to HTML 200 instead of returning JSON; intercept and synthesize results from `approvedRepoLib`. Covers the search-bar text search path. |
| 54699d0 | `pxt.github.repoAsync` | Hosted proxy returns nothing for some `/api/gh/<owner>/<repo>` lookups; synthesize a minimal repo object so the tile still renders. Covers direct repoAsync callers (download/install flow). |
| 23e6279 | `pxt.github.searchAsync` | The Extensions home view fast-paths slug-list queries through `searchAsync`'s closure-bound `repoAsync`, bypassing the namespace wrap above. Wrap `searchAsync` itself so home-view tiles for every preferred slug render. |
| 88517b8 | `targetconfig.json` `packages.releases.v7` | Pin `DFRobot/pxt-maqueen` to `v1.7.16`. Maqueen master (v1.7.17) bumped its required target to v8.0.22; v1.7.16 is the highest tag still declaring `targetVersions.target: 7.0.61`, which passes the major-version check against our v7.1.24 fork. Read by `pxt.github.latestVersionAsync` whenever an unpinned URL is resolved, so it covers manual install, saved-submission load, and tutorial-markdown ` ```package``` ` blocks. |

All three fallback wraps prefer the real upstream response when it works (e.g., local `pxt serve` hitting `makecode.com`) — synthesis only kicks in when the real source returns nothing. Real metadata flows through unchanged on local dev.

## Verify after deploy

1. `pxt staticpkg` against this branch, upload `built/packaged/`, bust CF cache (especially `main.js`, `pxtapp.js`, `targetconfig.json`), hard reload.

2. Open the Extensions panel — neopixel, sonar, oled-ssd1306, maqueen, cutebot, microturtle should all render alongside the bundled libs.

3. Click Install on maqueen — should resolve to `v1.7.16` and complete without the version error.

4. Console sanity check (inside the editor iframe):
   ```js
   [pxt.U._ssGhSearchPatched, pxt.github._ssRepoFallbackPatched, pxt.github._ssSearchFallbackPatched]
   // expect [true, true, true]

   pxt.packagesConfigAsync().then(c => c.releases?.v7)
   // expect ["DFRobot/pxt-maqueen#v1.7.16"]
   ```

## Maintenance note

If another kit extension bumps its target requirement past v7 in the future, add it to the same `packages.releases.v7` list pinned to its last v7-compatible tag. The long-term fix is upgrading the pxt-microbit fork itself from v7 → v8+; this PR is a target-stable workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
