### PR TITLE
Purge poisoned IndexedDB script cache + guard downloadPackageAsync [sc-33610]

### DIFF
--- a/editor/extension.tsx
+++ b/editor/extension.tsx
@@ -418,16 +418,27 @@ async function fetchPackageFromJsDelivr(repopath: string, tag: string): Promise<
     if (Array.isArray(parsed.testFiles)) declared.push(...parsed.testFiles);
 
     const files: { [k: string]: string } = { [configName]: configText };
+    const missing: string[] = [];
     await Promise.all(declared.map(async (name) => {
         if (files[name]) return; // already have it (configName, dedupe)
         try {
             const r = await fetch(`${base}/${encodeURI(name)}`);
             if (r.ok) files[name] = await r.text();
-            else pxt.debug(`jsDelivr file ${name} HTTP ${r.status} for ${slug}@${ref}`);
+            else {
+                pxt.debug(`jsDelivr file ${name} HTTP ${r.status} for ${slug}@${ref}`);
+                missing.push(`${name} (HTTP ${r.status})`);
+            }
         } catch (e) {
             pxt.debug(`jsDelivr file ${name} fetch failed for ${slug}@${ref}: ${e}`);
+            missing.push(`${name} (${e})`);
         }
     }));
+    // Fail closed on partial fetches so getPublishedScriptAsync's catch path
+    // skips caching this truncated result. Returning a partial map here would
+    // poison the IndexedDB script cache and re-create the bug this PR fixes.
+    if (missing.length) {
+        throw new Error(`jsDelivr partial fetch for ${slug}@${ref}: missing ${missing.join(", ")}`);
+    }
     return { files };
 }
 
@@ -481,6 +492,12 @@ async function purgePoisonedScriptCacheAsync(): Promise<void> {
         pxt.debug("indexedDB.databases() failed: " + e);
         return;
     }
+    // Scope the purge to databases that look PXT-owned. pxt-core's workspace
+    // DB co-locates "script" with a fixed set of other stores ("texts",
+    // "headers", "github", "hostcache"); a same-origin IndexedDB that happens
+    // to have a "script" store but none of these companions is not ours and
+    // we leave it alone.
+    const PXT_COMPANION_STORES = ["texts", "headers", "github", "hostcache"];
     for (const info of dbInfos) {
         if (!info.name) continue;
         await new Promise<void>((resolve) => {
@@ -488,6 +505,13 @@ async function purgePoisonedScriptCacheAsync(): Promise<void> {
             openReq.onsuccess = () => {
                 const db = openReq.result;
                 if (!db.objectStoreNames.contains("script")) {
+                    db.close();
+                    resolve();
+                    return;
+                }
+                const hasPxtCompanion = PXT_COMPANION_STORES.some(s => db.objectStoreNames.contains(s));
+                if (!hasPxtCompanion) {
+                    pxt.debug(`skipping non-PXT db with 'script' store: ${info.name}`);
                     db.close();
                     resolve();
                     return;

--- a/editor/extension.tsx
+++ b/editor/extension.tsx
@@ -48,6 +48,9 @@ pxt.editor.initExtensionsAsync = function (opts: pxt.editor.ExtensionOptions): P
     setupGitHubSearchFallback();
     setupGitHubLoadPackageFallback();
     setupGitHubIconFallback();
+    setupGitHubDownloadPackageGuard();
+    // Fire-and-forget; we don't want to block extension init on cache cleanup.
+    purgePoisonedScriptCacheAsync().catch(e => pxt.debug("purgePoisonedScriptCacheAsync failed: " + e));
 
     return Promise.resolve<pxt.editor.ExtensionResult>(res);
 }
@@ -426,4 +429,104 @@ async function fetchPackageFromJsDelivr(repopath: string, tag: string): Promise<
         }
     }));
     return { files };
+}
+
+// Skill Struck: pxt.github.downloadPackageAsync's return value flows into
+// getPublishedScriptAsync, which caches `result.files` into IndexedDB
+// (SCRIPT_TABLE) under the upgraded package id. When earlier install
+// attempts hit the broken hosted proxy *before* our fallback shipped,
+// the result was `{ files: undefined }` — and the workspace happily wrote
+// `files: undefined` to IndexedDB. Subsequent install clicks then hit the
+// cache, return undefined files, and crash in setFiles -> Object.keys.
+//
+// Wrap downloadPackageAsync to throw when the underlying loadPackageAsync
+// resolves with an empty/missing files map. A throw skips the cache write
+// in getPublishedScriptAsync's catch block, so future failed downloads
+// stop poisoning the cache. Combined with the IndexedDB purge below,
+// this prevents the bug from recurring and recovers users already stuck
+// from previous failed attempts.
+function setupGitHubDownloadPackageGuard() {
+    const github: any = (pxt as any).github;
+    if (!github || typeof github.downloadPackageAsync !== "function") return;
+    if (github._ssDownloadGuardPatched) return;
+    github._ssDownloadGuardPatched = true;
+    const orig = github.downloadPackageAsync;
+    github.downloadPackageAsync = async function (repoWithTag: string, config: any) {
+        const result = await orig.call(github, repoWithTag, config);
+        if (result && result.files && typeof result.files === "object" && Object.keys(result.files).length > 0) {
+            return result;
+        }
+        // Empty result. Try jsDelivr directly so we still install successfully.
+        pxt.debug("downloadPackageAsync empty for " + repoWithTag + ", refetching via jsDelivr");
+        const p: any = github.parseRepoId(repoWithTag);
+        if (!p) throw new Error("ss-guard: cannot parse repo id " + repoWithTag);
+        const tag = p.tag || (github.db && github.db.latestVersionAsync
+            ? await github.db.latestVersionAsync(p.slug, config)
+            : "master");
+        return fetchPackageFromJsDelivr(p.fullName, tag);
+    };
+}
+
+// Skill Struck: scan IndexedDB on init and delete script-cache entries
+// whose `files` is missing or empty. Such entries are leftover poison from
+// installs that ran against the broken proxy before the fallback shipped.
+// One-time cleanup per page load; on subsequent loads the cache is clean
+// and we're a no-op.
+async function purgePoisonedScriptCacheAsync(): Promise<void> {
+    if (typeof indexedDB === "undefined" || !(indexedDB as any).databases) return;
+    let dbInfos: { name?: string }[];
+    try {
+        dbInfos = await (indexedDB as any).databases();
+    } catch (e) {
+        pxt.debug("indexedDB.databases() failed: " + e);
+        return;
+    }
+    for (const info of dbInfos) {
+        if (!info.name) continue;
+        await new Promise<void>((resolve) => {
+            const openReq = indexedDB.open(info.name!);
+            openReq.onsuccess = () => {
+                const db = openReq.result;
+                if (!db.objectStoreNames.contains("script")) {
+                    db.close();
+                    resolve();
+                    return;
+                }
+                let tx: IDBTransaction;
+                try {
+                    tx = db.transaction("script", "readwrite");
+                } catch (e) {
+                    db.close();
+                    resolve();
+                    return;
+                }
+                const store = tx.objectStore("script");
+                const cursorReq = store.openCursor();
+                let purged = 0;
+                cursorReq.onsuccess = () => {
+                    const cursor = cursorReq.result;
+                    if (cursor) {
+                        const value = cursor.value;
+                        const files = value && value.files;
+                        const isEmpty = !files
+                            || typeof files !== "object"
+                            || Object.keys(files).length === 0;
+                        if (isEmpty) {
+                            cursor.delete();
+                            purged++;
+                        }
+                        cursor.continue();
+                    } else {
+                        if (purged > 0) pxt.debug(`purged ${purged} poisoned script-cache entries from ${info.name}`);
+                        db.close();
+                        resolve();
+                    }
+                };
+                cursorReq.onerror = () => { db.close(); resolve(); };
+                tx.onerror = () => { try { db.close(); } catch { } resolve(); };
+            };
+            openReq.onerror = () => resolve();
+            openReq.onblocked = () => resolve();
+        });
+    }
 }


### PR DESCRIPTION
## What this fixes

The jsDelivr file-fetch fallback in #9 wasn't enough to unblock click-install on hosted. Reason: pxt-core caches install results in an IndexedDB `script` object store, and users who tried installing before #9 shipped have poisoned cache entries from when the proxy was returning empty. Subsequent click-installs hit the cache first, return `undefined` files, and crash in `setFiles(undefined)` → `Object.keys(undefined)` → install dies silently. The post-fallback download code in #9 never executes for them.

## Sequence diagnosed

1. **Pre-#9**: User clicks Install on neopixel. Hosted proxy returns nothing usable. `pxt.github.downloadPackageAsync` resolves with `{ files: undefined }`.
2. `workspace.getPublishedScriptAsync` caches it:
    ```js
    await o.setAsync({ id: pkgId, files: undefined });
    ```
3. **Post-#9**: User clicks Install again. Cache hit short-circuits the network path:
    ```js
    try { i = (await o.getAsync(n)).files; }   // returns undefined from cache
    catch (s) { /* would call our fixed code, but never reached */ }
    ```
4. `setFiles(undefined)` crashes; install never completes.

## What this PR does

Two defenses:

### 1. `setupGitHubDownloadPackageGuard()`
Wraps `pxt.github.downloadPackageAsync`. When the underlying `loadPackageAsync` resolves with no files, refetch directly via jsDelivr instead of returning the empty object. If that also fails, *throw* — which causes `getPublishedScriptAsync`'s catch path to skip its cache write, keeping the cache clean for the next attempt.

### 2. `purgePoisonedScriptCacheAsync()`
Runs once at editor init: opens every IndexedDB on the origin, walks any `script` object store, and deletes entries whose `files` is missing/empty. One-time cleanup unblocks users whose cache was already poisoned. No-op on a clean cache (cheap; ~ms per page load).

Both are no-ops once everything is healthy — they only kick in if a previous install left bad data behind.

## Test plan
- [ ] `pxt staticpkg` against this branch, upload, bust Cloudflare cache for `main.js` and `pxtapp.js`.
- [ ] Hard reload a lesson page on hosted. Open Extensions, click neopixel → toolbox should now get the NeoPixel category and blocks.
- [ ] Repeat for sonar, microturtle, maqueen, cutebot, oled.
- [ ] Console sanity:
  ```js
  pxt.github._ssDownloadGuardPatched   // expect true
  ```
- [ ] To verify cache cleanup ran: in the iframe console after load, you may see a debug line like `purged N poisoned script-cache entries from <db-name>`. Subsequent reloads should show no purge log (cache is clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)